### PR TITLE
fix for crash when entering options dialog

### DIFF
--- a/trunk/Launchy_QT/src/options.cpp
+++ b/trunk/Launchy_QT/src/options.cpp
@@ -284,7 +284,8 @@ void OptionsDialog::setVisible(bool visible)
 	if (visible)
 	{
 		connect(skinList, SIGNAL(currentTextChanged(const QString)), this, SLOT(skinChanged(const QString)));
-		skinChanged(skinList->currentItem()->text());
+		QListWidgetItem *item = skinList->currentItem();
+		if (item) skinChanged(item->text());
 	}
 }
 


### PR DESCRIPTION
Hi, 

this fixes a frequent crash when entering the options dialog of the Qt4 Launchy: when skins are missing from the skins/ folder, Launch is not able to select the current skin from the skin list .

BR, Niels
