### PR TITLE
Fix hash calculation for catalog item of link

### DIFF
--- a/launchy/src/catalog.h
+++ b/launchy/src/catalog.h
@@ -116,7 +116,7 @@ public:
         usage = s.usage;
         data = s.data;
         id = s.id;
-        calculateHash();
+        hash = s.hash;
     }
 
     CatItem& operator=( const CatItem &s ) {
@@ -127,7 +127,7 @@ public:
         usage = s.usage;
         data = s.data;
         id = s.id;
-        calculateHash();
+        hash = s.hash;
         return *this;
     }
 
@@ -255,6 +255,7 @@ inline QDataStream &operator>>(QDataStream &in, CatItem &item) {
     in >> item.icon;
     in >> item.usage;
     in >> item.id;
+    item.calculateHash();
     return in;
 }
 

--- a/launchy/src/catalog.h
+++ b/launchy/src/catalog.h
@@ -135,7 +135,21 @@ public:
     {
         if ( isLink() ) {
             QFileInfo fime(fullPath);
-            hash = qHash(fime.symLinkTarget());
+            QString linkTarget = fime.symLinkTarget();
+            if (linkTarget != "") {
+                hash = qHash(linkTarget);
+            } else {
+                // Shortcut that points to virtual objects doesn't have target on Windows.
+                // Instead use file content for hash.
+                QFile file(fullPath);
+                if (file.open(QFile::ReadOnly)) {
+                    hash = qHash(file.readAll());
+                    file.close();
+                } else {
+                    // fallback to fullPath
+                    hash = qHash(fullPath);
+                }
+            }
         } else {
             hash = qHash(fullPath);
         }


### PR DESCRIPTION
`fime.symLinkTarget()` of some *.lnk files returns empty string on
Windows 10.  For example, Window Switcher.lnk, Shows Desktop.lnk
and Sticky Notes.lnk.
Hash is 0 and items are not added to catalog properly since hash
is used for item equality check.
As a workaround we calculate hash using `fullPath` if the link
target is empty.