### PR TITLE
Fix lupdate very slow with Boost

### DIFF
--- a/launchy/plugins/calcy/calcy.pro
+++ b/launchy/plugins/calcy/calcy.pro
@@ -10,6 +10,9 @@ VPATH += ../../src/
 
 INCLUDEPATH += ../../src/
 INCLUDEPATH += $$(BOOST_DIR)
+
+TR_EXCLUDE += $$(BOOST_DIR)/*
+
 PRECOMPILED_HEADER = precompiled.h
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += gui widgets

--- a/launchy/src/src.pro
+++ b/launchy/src/src.pro
@@ -15,6 +15,8 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets winextras
 INCLUDEPATH += ../common
 INCLUDEPATH += $$(BOOST_DIR)
 
+TR_EXCLUDE += $$(BOOST_DIR)/*
+
 SOURCES = main.cpp \
     globals.cpp \
     options.cpp \


### PR DESCRIPTION
`lupdate` is very slow with Boost 1_63 on Windows.

There is a workaround in the bug report (QTBUG-27936), involving the
TR_EXCLUDE option in the .pro project. It is used to tell `lupdate` to
exclude certain files.

http://stackoverflow.com/questions/40471662/update-translation-file-using-boost-library-qt-c